### PR TITLE
slim docker image

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,59 @@
+# FROM node:bullseye-slim # install-deps fails since it only supports Ubuntu
+# https://github.com/jlesage/docker-baseimage-gui
+# FROM jlesage/baseimage-gui:alpine-3.17-v4
+# 21MB base, 329MB, launching firefox fails, install-deps fails - apt-get: not found
+# FROM jlesage/baseimage-gui:ubuntu-20.04-v4
+# 48MB base, Node.js 10, but PW requires 14; after install curl and Node.js 19 via https://github.com/nodesource/distributions/ it only failed with running nightly firefox as root
+# FROM jlesage/baseimage-gui:debian-11-v4
+# 49MB base, Node.js 12, but PW requires 14
+# https://github.com/jlesage/docker-firefox
+FROM jlesage/firefox
+# 377MB base, 654MB, launching PW firefox fails with
+# browserType.launchPersistentContext: Failed to launch: Error: spawn /fgc/node_modules/playwright-core/.local-browsers/firefox-1372/firefox/firefox ENOENT
+# due to missing libs:
+# bash: ldd /fgc/node_modules/playwright-core/.local-browsers/firefox-1372/firefox/firefox
+# 	/lib/ld-linux-aarch64.so.1 (0xffffa7931000)
+# 	libpthread.so.0 => /lib/ld-linux-aarch64.so.1 (0xffffa7931000)
+# 	libdl.so.2 => /lib/ld-linux-aarch64.so.1 (0xffffa7931000)
+# 	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0xffffa7631000)
+# 	libm.so.6 => /lib/ld-linux-aarch64.so.1 (0xffffa7931000)
+# 	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0xffffa7600000)
+# 	libc.so.6 => /lib/ld-linux-aarch64.so.1 (0xffffa7931000)
+# ls /lib/ld-*
+# 	/lib/ld-musl-aarch64.so.1
+# -> try with   executablePath: '/usr/bin/firefox' in epic-games.js
+
+# docker build --tag fgc.slim -f Dockerfile.slim .
+# docker run --rm -it -p 5800:5800 -v $(realpath ./foo/fgc):/fgc/data -v $(realpath ./foo/firefox):/config:rw fgc.slim
+# -> stuck at dialog box 'Your Firefox profile cannot be loaded. It may be missing or inaccessible.'
+# -> Click OK via VNC -> Browser closed.
+
+# Install xterm.
+# RUN add-pkg xterm
+RUN add-pkg bash
+# RUN add-pkg curl
+# RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
+RUN add-pkg nodejs npm
+# RUN npx playwright install-deps firefox
+
+ENV HOME /fgc
+WORKDIR /fgc
+RUN mkdir /fgc/data
+COPY package*.json ./
+
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD true
+ENV PLAYWRIGHT_BROWSERS_PATH 0
+# If firefox is installed (~/.cache/ms-playwright/firefox-*) before `npm install` it may be a newer version than in package.json and playwright will not find it; system deps are installed sep. via apt above to avoid having to pin the version there.
+RUN npm install
+RUN npx playwright install firefox
+
+COPY . .
+
+# Show browser instead of running headless
+ENV SHOW 1
+
+# Copy the start script.
+COPY startapp.sh /startapp.sh
+
+# Set the name of the application.
+RUN set-cont-env APP_NAME "fgc"

--- a/notify-test.js
+++ b/notify-test.js
@@ -1,0 +1,36 @@
+import { html_game_list, notify } from "./util.js";
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const URL_CLAIM = 'https://gaming.amazon.com/home'; // dummy URL
+
+if (true) {
+  const notify_games = [
+    // { title: 'Kerbal Space Program', status: 'claimed', url: URL_CLAIM },
+    // { title: "Shadow Tactics - Aiko's Choice", status: 'claimed', url: URL_CLAIM },
+    { title: 'Epistory - Typing Chronicles', status: 'claimed', url: URL_CLAIM },
+  ];
+  notify(`epic-games:<br>${html_game_list(notify_games)}`);
+}
+
+if (false) {
+  await delay(1000);
+  const notify_games = [
+    { title: 'Faraway 2: Jungle Escape', status: 'claimed', url: URL_CLAIM },
+    { title: 'Chicken Police - Paint it RED!', status: 'claimed', url: URL_CLAIM },
+    { title: 'Lawn Mowing Simulator', status: 'claimed', url: URL_CLAIM },
+    { title: 'Breathedge', status: 'claimed', url: URL_CLAIM },
+    { title: 'The Evil Within 2', status: `<a href="${URL_CLAIM}">redeem</a> H97S6FB38FA6D09DEA on gog.com`, url: URL_CLAIM },
+    { title: 'Beat Cop', status: `<a href="${URL_CLAIM}">redeem</a> BMKM8558EC55F7B38F on gog.com`, url: URL_CLAIM },
+    { title: 'Dishonored 2', status: `<a href="${URL_CLAIM}">redeem</a> NNEK0987AB20DFBF8F on gog.com`, url: URL_CLAIM },
+  ];
+  notify(`prime-gaming:<br>${html_game_list(notify_games)}`);
+}
+
+if (false) {
+  await delay(1000);
+  const notify_games = [
+    { title: 'Haven Park', status: 'claimed', url: URL_CLAIM },
+  ];
+  notify(`gog:<br>${html_game_list(notify_games)}`);
+}

--- a/startapp.sh
+++ b/startapp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /fgc
+exec node epic-games.js


### PR DESCRIPTION
Current Docker image based on `ubuntu:jammy` is 1.12GB.

Tried out slim docker images with VNC (could be <400MB):
- https://github.com/jlesage/docker-baseimage-gui Alpine & Ubuntu
- https://github.com/jlesage/docker-firefox 377MB base, Alpine only

Alpine: installing deps and running firefox did not work - Playwright does not support Alpine: [issue](https://github.com/microsoft/playwright/issues/1986). Got `/usr/bin/firefox` to launch, but could not load profile.
Ubuntu: may work, but somehow could not install up-to-date nodejs to run `npx playwright`.


Other projects, but only supporting Chromium:
- https://github.com/Zenika/alpine-chrome
- https://github.com/fivemru/playwright-docker-alpine