### PR TITLE
add `LOGIN_TIMEOUT` with default 180s

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Available options/variables and their default values:
 | VNC_PASSWORD  	|         	| VNC password for Docker. No password used by default!                  	|
 | NOTIFY        	|         	| Notification services to use (Pushover, Slack, Telegram...), see below.	|
 | BROWSER_DIR   	| data/browser	| Directory for browser profile, e.g. for multiple accounts.         	|
-| LOGIN_TIMEOUT 	| 180     	| Timeout for login in seconds.                                          	|
+| LOGIN_TIMEOUT 	| 180     	| Timeout for login in seconds. Will wait twice (prompt + manual login). 	|
 | EMAIL         	|         	| Default email for any login.                                           	|
 | PASSWORD      	|         	| Default password for any login.                                        	|
 | EG_EMAIL      	|         	| Epic Games email for login. Overrides EMAIL.                           	|

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Available options/variables and their default values:
 | VNC_PASSWORD  	|         	| VNC password for Docker. No password used by default!                  	|
 | NOTIFY        	|         	| Notification services to use (Pushover, Slack, Telegram...), see below.	|
 | BROWSER_DIR   	| data/browser	| Directory for browser profile, e.g. for multiple accounts.         	|
+| LOGIN_TIMEOUT 	| 180     	| Timeout for login in seconds.                                          	|
 | EMAIL         	|         	| Default email for any login.                                           	|
 | PASSWORD      	|         	| Default password for any login.                                        	|
 | EG_EMAIL      	|         	| Epic Games email for login. Overrides EMAIL.                           	|

--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ export const cfg = {
   width: Number(process.env.WIDTH) || 1280, // width of the opened browser
   height: Number(process.env.HEIGHT) || 1280, // height of the opened browser
   timeout: (Number(process.env.TIMEOUT) || 20) * 1000, // 20s, default for playwright is 30s
+  login_timeout: (Number(process.env.LOGIN_TIMEOUT) || 180) * 1000, // higher 3min timeout for login
   novnc_port: process.env.NOVNC_PORT, // running in docker if set
   notify: process.env.NOTIFY, // apprise notification services
   get dir() { // avoids ReferenceError: Cannot access 'dataDir' before initialization

--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ export const cfg = {
   width: Number(process.env.WIDTH) || 1280, // width of the opened browser
   height: Number(process.env.HEIGHT) || 1280, // height of the opened browser
   timeout: (Number(process.env.TIMEOUT) || 20) * 1000, // 20s, default for playwright is 30s
-  login_timeout: (Number(process.env.LOGIN_TIMEOUT) || 180) * 1000, // higher 3min timeout for login
+  login_timeout: (Number(process.env.LOGIN_TIMEOUT) || 180) * 1000, // higher timeout for login, will wait twice: prompt + wait for manual login
   novnc_port: process.env.NOVNC_PORT, // running in docker if set
   notify: process.env.NOTIFY, // apprise notification services
   get dir() { // avoids ReferenceError: Cannot access 'dataDir' before initialization

--- a/epic-games.js
+++ b/epic-games.js
@@ -56,11 +56,11 @@ try {
   while (await page.locator('a[role="button"]:has-text("Sign In")').count() > 0) {
     console.error('Not signed in anymore. Please login in the browser or here in the terminal.');
     if (cfg.novnc_port) console.info(`Open http://localhost:${cfg.novnc_port} to login inside the docker container.`);
-    context.setDefaultTimeout(0); // give user time to log in without timeout
+    if (!cfg.debug) context.setDefaultTimeout(cfg.login_timeout); // give user some extra time to log in
+    console.info(`Login timeout is ${cfg.login_timeout/1000} seconds!`);
     await page.goto(URL_LOGIN, { waitUntil: 'domcontentloaded' });
-
     if (cfg.eg_email && cfg.eg_password) console.info('Using email and password from environment.');
-    else console.info('Press ESC to skip if you want to login in the browser.');
+    else console.info('Press ESC to skip the prompts if you want to login in the browser (not possible in headless mode).');
     const email = cfg.eg_email || await prompt({message: 'Enter email'});
     const password = email && (cfg.eg_password || await prompt({type: 'password', message: 'Enter password'}));
     if (email && password) {
@@ -85,7 +85,7 @@ try {
       notify('epic-games: no longer signed in and not enough options set for automatic login.');
     }
     await page.waitForURL(URL_CLAIM);
-    context.setDefaultTimeout(cfg.timeout);
+    if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
   }
   const user = await page.locator('#user span').first().innerHTML();
   console.log(`Signed in as ${user}`);

--- a/gog.js
+++ b/gog.js
@@ -40,9 +40,10 @@ try {
     // it then creates an iframe for the login
     await page.waitForSelector('#GalaxyAccountsFrameContainer iframe'); // TODO needed?
     const iframe = page.frameLocator('#GalaxyAccountsFrameContainer iframe');
-    context.setDefaultTimeout(0); // give user time to log in without timeout
+    if (!cfg.debug) context.setDefaultTimeout(cfg.login_timeout); // give user some extra time to log in
+    console.info(`Login timeout is ${cfg.login_timeout/1000} seconds!`);
     if (cfg.gog_email && cfg.gog_password) console.info('Using email and password from environment.');
-    else console.info('Press ESC to skip if you want to login in the browser (not possible in headless mode).');
+    else console.info('Press ESC to skip the prompts if you want to login in the browser (not possible in headless mode).');
     const email = cfg.gog_email || await prompt({message: 'Enter email'});
     const password = email && (cfg.gog_password || await prompt({type: 'password', message: 'Enter password'}));
     if (email && password) {
@@ -76,7 +77,7 @@ try {
         process.exit(1);
       }
     }
-    context.setDefaultTimeout(cfg.timeout);
+    if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
   }
   const user = await page.locator('#menuUsername').first().textContent(); // innerText is uppercase due to styling!
   console.log(`Signed in as '${user}'`);

--- a/notify-test.js
+++ b/notify-test.js
@@ -1,6 +1,4 @@
-import { html_game_list, notify } from "./util.js";
-
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+import { delay, html_game_list, notify } from "./util.js";
 
 const URL_CLAIM = 'https://gaming.amazon.com/home'; // dummy URL
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "cross-env": "^7.0.3",
         "dotenv": "^16.0.3",
+        "enquirer": "^2.3.6",
         "lowdb": "^5.1.0",
         "otplib": "^12.0.1",
         "playwright": "^1.30.0",
-        "prompts": "^2.4.2",
         "puppeteer-extra-plugin-stealth": "^2.11.1"
       }
     },
@@ -72,6 +72,14 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
@@ -175,6 +183,17 @@
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/for-in": {
@@ -311,14 +330,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -448,18 +459,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/puppeteer-extra-plugin": {
@@ -630,11 +629,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-    },
     "node_modules/steno": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/steno/-/steno-3.0.0.tgz",
@@ -738,6 +732,11 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+    },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
@@ -809,6 +808,14 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -915,11 +922,6 @@
         "is-buffer": "^1.1.5"
       }
     },
-    "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -1013,15 +1015,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
       "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g=="
     },
-    "prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "requires": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      }
-    },
     "puppeteer-extra-plugin": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.2.tgz",
@@ -1110,11 +1103,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "steno": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.3",
+    "enquirer": "^2.3.6",
     "lowdb": "^5.1.0",
     "otplib": "^12.0.1",
     "playwright": "^1.30.0",
-    "prompts": "^2.4.2",
     "puppeteer-extra-plugin-stealth": "^2.11.1"
   },
   "repository": {

--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -37,9 +37,10 @@ try {
   while (await page.locator('button:has-text("Sign in")').count() > 0) {
     console.error('Not signed in anymore.');
     await page.click('button:has-text("Sign in")');
-    if (!cfg.debug) context.setDefaultTimeout(0); // give user time to log in without timeout
+    if (!cfg.debug) context.setDefaultTimeout(cfg.login_timeout); // give user some extra time to log in
+    console.info(`Login timeout is ${cfg.login_timeout/1000} seconds!`);
     if (cfg.pg_email && cfg.pg_password) console.info('Using email and password from environment.');
-    else console.info('Press ESC to skip if you want to login in the browser (not possible in default headless mode).');
+    else console.info('Press ESC to skip the prompts if you want to login in the browser (not possible in headless mode).');
     const email = cfg.pg_email || await prompt({message: 'Enter email'});
     const password = email && (cfg.pg_password || await prompt({type: 'password', message: 'Enter password'}));
     if (email && password) {
@@ -67,7 +68,7 @@ try {
       console.log('Waiting for you to login in the browser.');
       notify('prime-gaming: no longer signed in and not enough options set for automatic login.');
       if (cfg.headless) {
-        console.log('Please run `SHOW=1 node prime-gaming` to login in the opened browser.');
+        console.log('Run `SHOW=1 node prime-gaming` to login in the opened browser.');
         await context.close(); // finishes potential recording
         process.exit(1);
       }

--- a/util.js
+++ b/util.js
@@ -17,6 +17,7 @@ export const jsonDb = async file => {
 };
 
 
+export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 // date and time as UTC (no timezone offset) in nicely readable and sortable format, e.g., 2022-10-06 12:05:27.313
 export const datetime = (d = new Date()) => d.toISOString().replace('T', ' ').replace('Z', '');
 // same as datetime() but for local timezone, e.g., UTC + 2h for the above in DE


### PR DESCRIPTION
Closes #69.
Instead of waiting forever, it now waits for `LOGIN_TIMEOUT` seconds (default 3min) at the prompt and for manual login in the browser.
-> Total wait 2x. (Hard to do differently since they're independent (if I cancel the prompt I still want enough time for manual login). Could have sep. options for prompt and wait, but seems overkill.)

Had to switch from https://github.com/terkelg/prompts to https://github.com/enquirer/enquirer which has `prompt.cancel()`.