### PR TITLE
URLs from JSON

### DIFF
--- a/epic-games.js
+++ b/epic-games.js
@@ -191,6 +191,9 @@ try {
       // I Agree button is only shown for EU accounts! https://github.com/vogler/free-games-claimer/pull/7#issuecomment-1038964872
       const btnAgree = page.locator('button:has-text("I Agree")');
       btnAgree.waitFor().then(() => btnAgree.click()).catch(_ => { }); // EU: wait for and click 'I Agree'
+
+      // May fail if game is already claimed with text 'Sorry, there is an error with your cart and we cannot complete the purchase. Please close this window and check your cart list.'
+
       try {
         // context.setDefaultTimeout(100 * 1000); // give time to solve captcha, iframe goes blank after 60s?
         const captcha = page.locator('#h_captcha_challenge_checkout_free_prod iframe');


### PR DESCRIPTION
Changes:
- [json](https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions) is parsed to get the current free games and construct their URLs instead of getting the URLs from the 'Free Now' buttons
- go to `purchaseURL` for each game instead of clicking the 'GET' button

I got a captcha with these changes, but may be due to testing during development.

Problems:
- Still need to visit each game page to check if game is already claimed since otherwise the order will fail. See TODO comment for options to speed it up (1. check order history, 2. check `epic-games.json`).

Untested:
- `unavailable-in-region`
- `EG_PARENTALPIN`
- `Thanks for your order`

Closes #127.