### PR TITLE
Add Docker Secrets Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Available options/variables and their default values:
 
 See `config.js` for all options.
 
+#### Using Secrets for Docker
+
+You can set any options/variables via [docker secrets](https://docs.docker.com/compose/use-secrets/) by appending `_FILE` to the variable/option name, e.g. to set `EG_PASSWORD` as secret replace it with `EG_PASSWORD_FILE` and setup secret as described in a docker documentation. You can find example in `docker-compose.yml`.
+
+If you set same options as variables and as secret, secret value will override variable.
+
 #### How to set options
 You can add options directly in the command or put them in a file to load.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,20 @@
 # start with `docker compose up`
+version: "3.7"
+
+secrets:
+  vnc_password:
+    file: .secrets/vnc_password_common
+  epic_user:
+    file: .secrets/epic_user
+  epic_password:
+    file: .secrets/epic_password
+  epic_otp:
+    file: .secrets/epic_otp
+
 services:
   free-games-claimer:
     container_name: fgc # is printed in front of every output line
     image: ghcr.io/vogler/free-games-claimer # otherwise image name will be free-games-claimer-free-games-claimer
-    build: .
     ports:
       # - "5900:5900" # VNC server
       - "6080:6080" # noVNC (browser-based VNC client)
@@ -13,3 +24,30 @@ services:
     environment:
       # - EMAIL=foo@bar.org
       # - NOTIFY='tgram://...'
+      # - NOTIFY_TITLE="Optional title for notifications"
+      # - VNC_PASSWORD="VNC Password"
+      - VNC_PASSWORD_FILE=/run/secrets/vnc_password
+      # - BROWSER_DIR="data/browser"
+      # - TIMEOUT="60"
+      # - LOGIN_TIMEOUT="80"
+      # - EMAIL="Default email for any login"
+      # - PASSWORD="Default password for any login"
+      # - EG_EMAIL="Epic Games email for login"
+      # - EG_PASSWORD="Epic Games password for login"
+      # - EG_OTPKEY="Epic Games MFA OTP key"
+      - EG_EMAIL_FILE=/run/secrets/epic_user
+      - EG_PASSWORD_FILE=/run/secrets/epic_password
+      - EG_OTPKEY_FILE=/run/secrets/epic_otp
+      # - EG_PARENTALPIN="Epic Games Parental Controls PIN"
+      # - PG_EMAIL="Prime Gaming email for login"
+      # - PG_PASSWORD="Prime Gaming password for login"
+      # - PG_OTPKEY="Prime Gaming MFA OTP key"
+      # - PG_REDEEM="0"
+      # - PG_CLAIMDLC="0"
+      # - GOG_EMAIL="GOG email for login"
+      # - GOG_PASSWORD="GOG Password"
+    secrets:
+      - epic_user
+      - epic_password
+      - epic_otp
+      - vnc_password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,34 @@ rm -f /fgc/data/browser/SingletonLock
 # ls -l /tmp/.X11-unix/
 rm -f /tmp/.X1-lock
 
+# Check and export secrets to variables if exist
+# Get list of VARIABLES with "_FILE" at the end
+SECRETS_LIST=$(env | grep "_FILE")
+if [ ! -z "$SECRETS_LIST" ]; then
+
+    echo "Secrets were found, will try to convert them into the Variables..."
+
+    # Will read one by one, remove "_FILE" from the end and get value from the file
+    # Known bug: if you set "=" in the variable value, it will be converted to the space
+    while read SECRETS; do
+        SECRET_VALUE=$(echo $SECRETS | awk -F'[=]' '{ $1=""; print $0 }')
+        # Remove unneeded space at the begging
+        SECRET_VALUE=${SECRET_VALUE:1}
+        SECRET_NAME=$(echo $SECRETS | awk -F'[=]' '{ print $1 }')
+        # Remove "_FILE" at the end of the Variable Name
+        SECRET_NAME=${SECRET_NAME::-5}
+
+        # If file with value readable, use it to fetch value and export variable
+        if [ -r "$SECRET_VALUE" ]; then
+            echo "Setting $SECRET_NAME with value from $SECRET_VALUE"
+            export "$SECRET_NAME"="$(cat "$SECRET_VALUE")"
+        else
+            echo "ERROR - $SECRETS is configured, but file not exist or not readable."
+        fi
+    done <<< $SECRETS_LIST
+
+fi
+
 # 6000+SERVERNUM is the TCP port Xvfb is listening on:
 # SERVERNUM=$(echo "$DISPLAY" | sed 's/:\([0-9][0-9]*\).*/\1/')
 


### PR DESCRIPTION
Documentation Update
Add more examples to the compose

Now any Variable that set with `_FILE` at the end will be treatment as [Docker Secret](https://docs.docker.com/compose/use-secrets/).