### PR TITLE
Enable random delay on start to avoid captcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Available options/variables and their default values:
 | WIDTH         	| 1280    	| Width of the opened browser (and of screen for VNC in Docker).         	|
 | HEIGHT        	| 1280    	| Height of the opened browser (and of screen for VNC in Docker).        	|
 | VNC_PASSWORD  	|         	| VNC password for Docker. No password used by default!                  	|
+| DELAY_ON_START	| false    	| Enable Random delay on start if was set to `true`.                     	|
+| DELAY_ON_START_MAXIMUM	| 300     	| Specify maximum delay on start if enabled, default is 300 seconds.	|
 | NOTIFY        	|         	| Notification services to use (Pushover, Slack, Telegram...), see below.	|
 | NOTIFY_TITLE  	|         	| Optional title for notifications, e.g. for Pushover.                   	|
 | BROWSER_DIR   	| data/browser	| Directory for browser profile, e.g. for multiple accounts.         	|

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,19 @@ rm -f /fgc/data/browser/SingletonLock
 # ls -l /tmp/.X11-unix/
 rm -f /tmp/.X1-lock
 
+# Enable random start delay to aviod captcha by parallel execution
+if [[ "$DELAY_ON_START" == "true" ]]; then
+
+    # Set maxumum delay. Default is 300 Seconds.
+    DELAY_ON_START_MAXIMUM="${DELAY_ON_START_MAXIMUM:-300}"
+    # Get random vaule within Range
+    DELAY_ON_START_SECONDS="$((RANDOM % DELAY_ON_START_MAXIMUM))"
+    echo "Random delay on start was enabled, will wait $DELAY_ON_START_SECONDS seconds..."
+    sleep $DELAY_ON_START_SECONDS
+    echo "Continue."
+
+fi
+
 # 6000+SERVERNUM is the TCP port Xvfb is listening on:
 # SERVERNUM=$(echo "$DISPLAY" | sed 's/:\([0-9][0-9]*\).*/\1/')
 


### PR DESCRIPTION
By parallel execution some containers will be blocked by captcha, this can be avoided by random delay on start.