### PR TITLE
Ability to use a different email for Legacy Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Available options/variables and their default values:
 | GOG_EMAIL     	|         	| GOG email for login. Overrides EMAIL.                                  	|
 | GOG_PASSWORD  	|         	| GOG password for login. Overrides PASSWORD.                            	|
 | GOG_NEWSLETTER	| 0       	| Do not unsubscribe from newsletter after claiming a game if 1.         	|
+| LG_EMAIL        |         	| Legacy Games: email to use for redeeming (if not set, defaults to PG_EMAIL)  |
 
 See `src/config.js` for all options.
 

--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -243,8 +243,8 @@ try {
             }
           } else if (store == 'legacy games') {
             await page2.fill('[name=coupon_code]', code);
-            await page2.fill('[name=email]', cfg.pg_email); // TODO option for sep. email?
-            await page2.fill('[name=email_validate]', cfg.pg_email);
+            await page2.fill('[name=email]', cfg.lg_email);
+            await page2.fill('[name=email_validate]', cfg.lg_email);
             await page2.uncheck('[name=newsletter_sub]');
             await page2.click('[type="submit"]');
             try {

--- a/src/config.js
+++ b/src/config.js
@@ -49,4 +49,6 @@ export const cfg = {
   // experimmental - likely to change
   pg_redeem: process.env.PG_REDEEM == '1', // prime-gaming: redeem keys on external stores
   pg_claimdlc: process.env.PG_CLAIMDLC == '1', // prime-gaming: claim in-game content
+  // external stores
+  lg_email: process.env.LG_EMAIL || process.env.PG_EMAIL || process.env.EMAIL, // legacy-games: email to use for redeeming
 };


### PR DESCRIPTION
Added the `LG_EMAIL` config var to have the option to use a different email when redeeming codes on Legacy Games. If not set, will default to `PG_EMAIL` as it currently does.