### PR TITLE
new GOG.com reedem links for games via prime gaming

### DIFF
--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -172,7 +172,7 @@ try {
         if (store == 'legacy games') { // may be different URL like https://legacygames.com/primeday/puzzleoftheyear/
           redeem[store] = await (await page.$('li:has-text("Click here") a')).getAttribute('href'); // full text: Click here to enter your redemption code.
         }
-        console.log('  URL to redeem game:', redeem[store]);
+        console.log('  URL to redeem game:' + redeem[store] + '/' + code);
         db.data[user][title].code = code;
         let redeem_action = 'redeem';
         if (cfg.pg_redeem) { // try to redeem keys on external stores


### PR DESCRIPTION
Added the redeem code to the link for gog.com */redeem/[code]* in the prime gaming module. You don't have to copy-paste the code anymore.