### PR TITLE
fix: docker-entrypoint.sh uses safe shebang

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail # exit on error, error on any fail in pipe (not just last cmd); add -x to print each cmd; see gist bash_strict_mode.md
 


### PR DESCRIPTION
Shebangs should use `/usr/bin/env` to locate the interpreter. Setting a path directly to the interpreter itself tends to be brittle and prone to breaking.