### PR TITLE
docker rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,11 @@ COPY . .
 RUN dos2unix ./*.sh && chmod +x ./*.sh
 COPY docker-entrypoint.sh /usr/local/bin/
 
+# set by .github/workflows/docker.yml
 ARG COMMIT=""
 ARG BRANCH=""
 ARG NOW=""
+# need as env vars to log in docker-entrypoint.sh
 ENV COMMIT=${COMMIT}
 ENV BRANCH=${BRANCH}
 ENV NOW=${NOW}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,9 +36,10 @@ rm -f /tmp/.X1-lock
 # Options passed directly to the Xvfb server:
 # -ac disables host-based access control mechanisms
 # −screen NUM WxHxD creates the screen and sets its width, height, and depth
+# -nolisten unix tells the server not to use Unix domain sockets, thus avoiding the need to create /tmp/.X11-unix
 
 export DISPLAY=:1 # need to export this, otherwise playwright complains with 'Looks like you launched a headed browser without having a XServer running.'
-Xvfb $DISPLAY -ac -screen 0 "${WIDTH}x${HEIGHT}x${DEPTH}" &
+Xvfb $DISPLAY -ac -screen 0 "${WIDTH}x${HEIGHT}x${DEPTH}" -nolisten unix &
 echo "Xvfb display server created screen with resolution ${WIDTH}x${HEIGHT}"
 if [ -z "$VNC_PASSWORD" ]; then
 	pw="-nopw"


### PR DESCRIPTION
- **lint: fix most super-linter errors**
- **fix eslint errors**
- **Contributing: how to create a pull request**
- **dependabot: ignore eslint and group devDependencies into one PR**
- **pg: fix eslint no-async-promise-executor**
- **docker: use metadata-action for tags and labels**
- **docker: GitHub doesn't show labels due to multi-arch image -> add annotation level index**
- **docker: comment out all labels since they're added?**
- **docker: rm old labels**
- **lint.yml -> super-linter.yml**
- **npx mega-linter-runner --install # all defaults**
- **use megalinter cupcake flavor (88 vs 127 linter, 5 vs 10GB image)**
- **run for PRs against main or dev**
- **comment how to run locally**
- **markdown config**
- **megalinter markdown**
- **megalinter yaml (funny that this complains about their own generated config...)**
- **megalinter yaml: fix wrong auto-fix**
- **megalinter "''" needed for lists in env var**
- **disable markdownlint line-length**
- **megalinter reports also in json and md instead of just log**
- **megalinter customize config; local run ~7min...**
- **megalinter: upload-sarif needs more permissons?**
- **megalinter: upload-sarif category**
- **megalinter: job summary from markdown file**
- **remove super-linter in favor of mega-linter**
- **megalinter apparently can't push commit fixing workflows without a sep. PAT**
- **added PAT for megalinter with workflows permission**
- **[MegaLinter] Apply linters fixes**
- **skip docker push for PRs**
- **ncu -u; migrate @stylistic/eslint-plugin{-js,}**
- **eslint with sarif upload**
- **eslint.yml -> js.yml**
- **run eslint with sarif and then normally?**
- **ci/js: check size of dependencies**
- **dep size in job summary?**
- **howfat tables don't work as md**
- **nicer md for job summary**
- **switch ci from npm to bun**
- **bun install almost twice as fast**
- **rm @microsoft/eslint-formatter-sarif (uses its own old eslint) and wget sarif.js**
- **rm cross-env for `npm run docker` since it wasn't working right - readme as single source of truth for `docker run` cmd**
- **log (un)compressed docker image size = shared + unique**
- **need other commands to get sizes for docker buildx?**
- **.dockerignore = strict superset of .gitignore, not DRY, but ok...**
- **uncompressed docker size with buildx**
- **docker image rm buildkit stuff?**
- **can't remove buildkit images?**
- **grep size for image from df output**
- **echo -e for \n**
- **use emd/cmd for js.yml**
- **same triggers (push, PRs) for js, mega-linter, sonar**
- **upgrade deprecated sonarcloud-github-action -> sonarqube-scan-action**
- **fix js.yml**
- **fix actionlint/shellcheck: $@ -> $***
- **js.yml forgot one npx -> bunx**
- **fix SonarQube Scan version**
- **respect INTERACTIVE=1 in gog and eg, not just pg**
- **NOWAIT=1 to fail fast instead of waiting for user input**
- **fix b4dcd0b: $@ needed to run command...**
- **only run js/sonarqube for changes to **.js, **.ts, package.json**
- **add healthcheck (just checks for node) to Dockerfile and docker-compose.yml**
- **docker healthcheck: check that noVNC is reachable (and node running)**
- **docker: comment on ARG -> ENV**
- **docker: user fgc instead of root, fixes #468, how to deal with existing volumes?**
