### PR TITLE
docker: user fgc instead of root

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,9 +36,10 @@ rm -f /tmp/.X1-lock
 # Options passed directly to the Xvfb server:
 # -ac disables host-based access control mechanisms
 # −screen NUM WxHxD creates the screen and sets its width, height, and depth
+# -nolisten unix tells the server not to use Unix domain sockets, thus avoiding the need to create /tmp/.X11-unix
 
 export DISPLAY=:1 # need to export this, otherwise playwright complains with 'Looks like you launched a headed browser without having a XServer running.'
-Xvfb $DISPLAY -ac -screen 0 "${WIDTH}x${HEIGHT}x${DEPTH}" &
+Xvfb $DISPLAY -ac -screen 0 "${WIDTH}x${HEIGHT}x${DEPTH}" -nolisten unix &
 echo "Xvfb display server created screen with resolution ${WIDTH}x${HEIGHT}"
 if [ -z "$VNC_PASSWORD" ]; then
 	pw="-nopw"


### PR DESCRIPTION
Fixes #468.

This works when running with a fresh volume:
![image](https://github.com/user-attachments/assets/63a453f9-d9ad-467d-94bb-73f2cc35b2e1)
But fails for existing volumes which have `/fgc/data` owned by root:
![image](https://github.com/user-attachments/assets/1d663a4b-36d3-4069-a475-748122465fa5)

I guess one could give people a `docker run` command to fix permissions, but not sure if it's worth the headache.

Notes:
- https://www.perplexity.ai/search/what-are-the-security-implicat-rnKzzmcGShKTm.nEaAT0tQ#0
- https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html
- https://www.docker.com/blog/understanding-the-docker-user-instruction/
- https://www.perplexity.ai/search/how-can-i-fix-permissions-in-a-6Zy_uhnqQ6Gny2SSXy7.uQ#0
  - would require people to change permissions for their existing `fgc` volume? keep root, chown in entrypoint, and later change default user?
  - when you mount a volume on a directory it inherits the ownership of that directory?
  - when using docker volumes, the created volume will be preseeded with the permissions from the image when you first connect it?