### PR TITLE
fix: prime-gaming dlc content

### DIFF
--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -363,7 +363,7 @@ try {
   // https://github.com/vogler/free-games-claimer/issues/55
   if (cfg.pg_claimdlc) {
     console.log('Trying to claim in-game content...');
-    await page.click('button[data-type="InGameLoot"]');
+    await page.click('button[data-type="All"]');
     const loot = page.locator('div[data-a-target="offer-list-IN_GAME_LOOT"]');
     await loot.waitFor();
 


### PR DESCRIPTION
* specific dlc tab is not available anymore

The DLC content is available on the "All" Tab


closes #451 

Tested the change locally and works for me:

<img width="371" alt="grafik" src="https://github.com/user-attachments/assets/a9cc6ced-f8db-46cb-b8a0-fdeecc194f18" />
