### PR TITLE
Update Prime Gaming OTP key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you set the options for email, password and OTP key, there will be no prompts
 To get the OTP key, it is easiest to follow the store's guide for adding an authenticator app. You should also scan the shown QR code with your favorite app to have an alternative method for 2FA.
 
 - **Epic Games**: visit [password & security](https://www.epicgames.com/account/password), enable 'third-party authenticator app', copy the 'Manual Entry Key' and use it to set `EG_OTPKEY`.
-- **Prime Gaming**: visit Amazon 'Your Account › Login & security', 2-step verification › Manage › Add new app › Can't scan the barcode, copy the bold key and use it to set `PG_OTPKEY`
+- **Prime Gaming**: visit Amazon 'Your Account › Login & security', 2-step verification › Manage › Add new app › Can't scan the barcode, copy the bold key, remove the spaces and use it to set `PG_OTPKEY`
 - **GOG**: only offers OTP via email
 <!-- - **Xbox**: visit [additional security](https://account.live.com/proofs/manage/additional) > Add a new way to sign in or verify > Use an app > Set up a different Authenticator app > I can't scan the bar code > copy the bold key and use it to set `XBOX_OTPKEY` -->
 


### PR DESCRIPTION
Add instructions to remove the spaces when setting the Prime Gaming OTP key
Resolves #162