### PR TITLE
feat: switch to patchright/Chromium, add Steam claimer, scheduler, Telegram, HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # FROM mcr.microsoft.com/playwright:v1.20.0
 # Partially from https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.focal
 FROM ubuntu:jammy
+# Using patchright (patched Chromium) instead of playwright-firefox for better bot detection bypass
 
 # Configuration variables are at the end!
 
@@ -22,8 +23,9 @@ RUN apt-get update \
       tini \
       novnc websockify \
       dos2unix \
+      bc \
       python3-pip \
-    # && npx playwright install-deps firefox \
+    # Chromium (patchright) system dependencies:
     && apt-get install --no-install-recommends -y \
       libgtk-3-0 \
       libasound2 \
@@ -31,11 +33,20 @@ RUN apt-get update \
       libpangocairo-1.0-0 \
       libpango-1.0-0 \
       libatk1.0-0 \
+      libatk-bridge2.0-0 \
       libcairo-gobject2 \
       libcairo2 \
       libgdk-pixbuf-2.0-0 \
-      libdbus-glib-1-2 \
+      libdbus-1-3 \
       libxcursor1 \
+      libxdamage1 \
+      libxrandr2 \
+      libgbm1 \
+      libxss1 \
+      libnss3 \
+      libnspr4 \
+      libcups2 \
+      libxkbcommon0 \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf \
@@ -57,15 +68,16 @@ COPY package*.json ./
 # Playwright installs patched firefox to ~/.cache/ms-playwright/firefox-*
 # Requires some system deps to run (see inlined install-deps above).
 RUN npm install
-# Old: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD + install firefox (had to be done after `npm install` to get the correct version). Now: playwright-firefox as npm dep and `npm install` will only install that.
-# From 1.38 Playwright will no longer install browser automatically for playwright, but apparently still for playwright-firefox: https://github.com/microsoft/playwright/releases/tag/v1.38.0
-# RUN npx playwright install firefox
+# Install patchright's patched Chromium browser binary
+RUN npx patchright install chromium
 
 COPY . .
 
 # Shell scripts need Linux line endings. On Windows, git might be configured to check out dos/CRLF line endings, so we convert them for those people in case they want to build the image. They could also use --config core.autocrlf=input
 RUN dos2unix ./*.sh && chmod +x ./*.sh
 COPY docker-entrypoint.sh /usr/local/bin/
+# Make scheduler available as absolute path (used in docker-compose command)
+RUN chmod +x /fgc/run-scheduled.sh
 
 ARG COMMIT=""
 ARG BRANCH=""
@@ -98,7 +110,13 @@ ENV DEPTH 24
 # Show browser instead of running headless
 ENV SHOW 1
 
+# HEALTHCHECK: passes if lastrun.json was updated within the last 25 hours (1500 min).
+# Fails if the scheduler is stuck or hasn't run since container start.
+HEALTHCHECK --interval=30m --timeout=10s --start-period=120s --retries=3 \
+  CMD find /fgc/data/lastrun.json -mmin -1500 > /dev/null 2>&1 || exit 1
+
 # Script to setup display server & VNC is always executed.
 ENTRYPOINT ["docker-entrypoint.sh"]
 # Default command to run. This is replaced by appending own command, e.g. `docker run ... node prime-gaming` to only run this script.
-CMD node epic-games; node prime-gaming; node gog
+CMD node epic-games; node prime-gaming; node gog; node steam-games
+# For scheduled daily runs, override CMD with: /fgc/run-scheduled.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,52 @@
-# start with `docker compose up`
+# start with `docker compose up -d`
 services:
   free-games-claimer:
-    container_name: fgc # is printed in front of every output line
-    image: ghcr.io/vogler/free-games-claimer # otherwise image name will be free-games-claimer-free-games-claimer
+    container_name: fgc
+    image: ghcr.io/vogler/free-games-claimer
     build: .
+    restart: unless-stopped   # auto-restart after crash or docker daemon restart
     ports:
       # - "5900:5900" # VNC server
       - "6080:6080" # noVNC (browser-based VNC client)
     volumes:
       - fgc:/fgc/data
-    # command: bash -c "node epic-games; node gog"
+    # Run scripts once and exit (original behavior):
+    # command: bash -c "node epic-games; node prime-gaming; node gog; node steam-games"
+    #
+    # Run on schedule (default: every day at 07:00) - recommended for Portainer:
+    command: /fgc/run-scheduled.sh
     environment:
-      # - EMAIL=foo@bar.org
-      # - NOTIFY='tgram://...'
+      - SCHEDULE_HOUR=7         # hour of day (0-23) for daily run
+      # - SCRIPTS=node epic-games; node gog   # override which scripts run
+
+      # Epic Games Store
+      # - EG_EMAIL=epic@foo.org
+      # - EG_PASSWORD=secret
+      # - EG_OTPKEY=BASE32KEYHERE
+
+      # Amazon Prime Gaming
+      # - PG_EMAIL=amazon@foo.org
+      # - PG_PASSWORD=secret
+      # - PG_OTPKEY=BASE32KEYHERE
+
+      # GOG
+      # - GOG_EMAIL=gog@foo.org
+      # - GOG_PASSWORD=secret
+
+      # Steam
+      # - STEAM_USERNAME=mysteamlogin
+      # - STEAM_PASSWORD=secret
+      # - STEAM_OTPKEY=BASE32KEYHERE   # Steam Guard app OTP key
+
+      # Notifications (use one or both)
+      # Option A: Telegram (no external deps)
+      # - TG_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTuVwXyZ
+      # - TG_CHAT_ID=-100123456789
+      # Option B: Apprise (pip install apprise) - supports 60+ services
+      # - NOTIFY=tgram://bot_token/chat_id
+
+      # - EMAIL=shared@foo.org     # fallback email for all stores
+      # - SHOW=0                   # disable VNC display (headless only)
+
+volumes:
+  fgc:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,7 +28,7 @@ EOT
 # Remove X server display lock, fix for `docker compose up` which reuses container which made it fail after initial run, https://github.com/vogler/free-games-claimer/issues/31
 # echo $DISPLAY
 # ls -l /tmp/.X11-unix/
-rm -f /tmp/.X1-lock
+rm -f /tmp/.X11-lock
 
 # 6000+SERVERNUM is the TCP port Xvfb is listening on:
 # SERVERNUM=$(echo "$DISPLAY" | sed 's/:\([0-9][0-9]*\).*/\1/')

--- a/epic-games.js
+++ b/epic-games.js
@@ -1,9 +1,9 @@
-import { firefox } from 'playwright-firefox'; // stealth plugin needs no outdated playwright-extra
+import { chromium } from 'patchright'; // patchright patches Chromium to bypass bot detection (captcha, Cloudflare)
 import { authenticator } from 'otplib';
 import chalk from 'chalk';
 import path from 'path';
-import { existsSync, writeFileSync, appendFileSync } from 'fs';
-import { resolve, jsonDb, datetime, stealth, filenamify, prompt, notify, html_game_list, handleSIGINT } from './src/util.js';
+import { existsSync, writeFileSync } from 'fs';
+import { resolve, jsonDb, datetime, stealth, filenamify, prompt, notify, html_game_list, handleSIGINT, clearBrowserLock, writeLastRun, withRetry, generateFingerprint } from './src/util.js';
 import { cfg } from './src/config.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'epic-games', ...a);
@@ -17,35 +17,28 @@ const db = await jsonDb('epic-games.json', {});
 
 if (cfg.time) console.time('startup');
 
-const browserPrefs = path.join(cfg.dir.browser, 'prefs.js');
-if (existsSync(browserPrefs)) {
-  console.log('Adding webgl.disabled to', browserPrefs);
-  appendFileSync(browserPrefs, 'user_pref("webgl.disabled", true);'); // apparently Firefox removes duplicates (and sorts), so no problem appending every time
-} else {
-  console.log(browserPrefs, 'does not exist yet, will patch it on next run. Restart the script if you get a captcha.');
-}
+clearBrowserLock(cfg.dir.browser);
+
+const fp = generateFingerprint(cfg.width, cfg.height);
 
 // https://playwright.dev/docs/auth#multi-factor-authentication
-const context = await firefox.launchPersistentContext(cfg.dir.browser, {
+const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
-  userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20100101 Firefox/127.0', // see replace of Headless in util.newStealthContext. TODO Windows UA enough to avoid 'device not supported'? update if browser is updated?
-  // userAgent firefox (macOS): Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:106.0) Gecko/20100101 Firefox/106.0
-  // userAgent firefox (docker): Mozilla/5.0 (X11; Linux aarch64; rv:109.0) Gecko/20100101 Firefox/115.0
+  userAgent: fp.fingerprint.navigator.userAgent,
   locale: 'en-US', // ignore OS locale to be sure to have english text for locators
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/eg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
+  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
+  recordHar: cfg.record ? { path: `data/record/eg-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
-  // user settings for firefox have to be put in $BROWSER_DIR/user.js
-  args: [ // https://wiki.mozilla.org/Firefox/CommandLineOptions
-    // '-kiosk',
+  args: [
+    '--disable-blink-features=AutomationControlled', // extra stealth on top of patchright patches
   ],
 });
 
 handleSIGINT(context);
 
 // Without stealth plugin, the website shows an hcaptcha on login with username/password and in the last step of claiming a game. It may have other heuristics like unsuccessful logins as well. After <6h (TBD) it resets to no captcha again. Getting a new IP also resets.
-await stealth(context);
+await stealth(context, fp);
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
@@ -156,8 +149,8 @@ try {
 
   for (const url of urls) {
     if (cfg.time) console.time('claim game');
-    await page.goto(url); // , { waitUntil: 'domcontentloaded' });
-    const purchaseBtn = page.locator('button[data-testid="purchase-cta-button"] >> :has-text("e"), :has-text("i")').first(); // when loading, the button text is empty -> need to wait for some text {'get', 'in library', 'requires base game'} -> just wait for e or i to not be too specific; :text-matches("\w+") somehow didn't work - https://github.com/vogler/free-games-claimer/issues/375
+    await withRetry(`goto ${url}`, () => page.goto(url), { retries: 3, delayMs: 15000 });
+    const purchaseBtn = page.locator('button[data-testid="purchase-cta-button"]').filter({ hasText: /[ei]/i }); // when loading, the button text is empty -> need to wait for some text {'get', 'in library', 'requires base game'} -> just wait for e or i to not be too specific; >> selector was deprecated in Playwright - https://github.com/vogler/free-games-claimer/issues/375
     await purchaseBtn.waitFor();
     const btnText = (await purchaseBtn.innerText()).toLowerCase(); // barrier to block until page is loaded
 
@@ -228,7 +221,7 @@ try {
       // Accept End User License Agreement (only needed once)
       page.locator(':has-text("end user license agreement")').waitFor().then(async () => {
         console.log('  Accept End User License Agreement (only needed once)');
-        console.log(page.innerHTML);
+        console.log(await page.innerHTML('body'));
         console.log('Please report the HTML above here: https://github.com/vogler/free-games-claimer/issues/371');
         await page.locator('input#agree').check(); // TODO Bundle: got stuck here; likely unrelated to bundle and locator just changed: https://github.com/vogler/free-games-claimer/issues/371
         await page.locator('button:has-text("Accept")').click();
@@ -315,6 +308,7 @@ try {
   if (error.message && process.exitCode != 130) notify(`epic-games failed: ${error.message.split('\n')[0]}`);
 } finally {
   await db.write(); // write out json db
+  writeLastRun('epic-games');
   if (notify_games.filter(g => g.status == 'claimed' || g.status == 'failed').length) { // don't notify if all have status 'existed', 'manual', 'requires base game', 'unavailable-in-region', 'skipped'
     notify(`epic-games (${user}):<br>${html_game_list(notify_games)}`);
   }

--- a/gog.js
+++ b/gog.js
@@ -1,6 +1,6 @@
-import { firefox } from 'playwright-firefox'; // stealth plugin needs no outdated playwright-extra
+import { chromium } from 'patchright'; // patchright patches Chromium to bypass bot detection
 import chalk from 'chalk';
-import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, handleSIGINT } from './src/util.js';
+import { resolve, jsonDb, datetime, filenamify, prompt, notify, html_game_list, handleSIGINT, clearBrowserLock, writeLastRun, stealth, generateFingerprint } from './src/util.js';
 import { cfg } from './src/config.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'gog', ...a);
@@ -11,22 +11,33 @@ console.log(datetime(), 'started checking gog');
 
 const db = await jsonDb('gog.json', {});
 
+clearBrowserLock(cfg.dir.browser);
+
 if (cfg.width < 1280) { // otherwise 'Sign in' and #menuUsername are hidden (but attached to DOM), see https://github.com/vogler/free-games-claimer/issues/335
   console.error(`Window width is set to ${cfg.width} but needs to be at least 1280 for GOG!`);
   process.exit(1);
 }
 
+const fp = generateFingerprint(cfg.width, cfg.height);
+
 // https://playwright.dev/docs/auth#multi-factor-authentication
-const context = await firefox.launchPersistentContext(cfg.dir.browser, {
+const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
+  userAgent: fp.fingerprint.navigator.userAgent,
   locale: 'en-US', // ignore OS locale to be sure to have english text for locators -> done via /en in URL
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/gog-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
+  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
+  recordHar: cfg.record ? { path: `data/record/gog-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
+  args: [
+    '--disable-blink-features=AutomationControlled',
+  ],
 });
 
 handleSIGINT(context);
+
+// stealth: sets window.chrome, navigator.plugins, etc. + injects consistent fingerprint
+await stealth(context, fp);
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
@@ -101,11 +112,15 @@ try {
   } else {
     const text = await page.locator('.giveaway__content-header').innerText();
     const match_all = text.match(/Claim (.*) and don't miss the|Success! (.*) was added to/);
-    const title = match_all[1] ? match_all[1] : match_all[2];
+    if (!match_all) {
+      console.error('Could not parse giveaway title from text:', text);
+      throw new Error('Failed to parse GOG giveaway title');
+    }
+    const title = match_all[1] ?? match_all[2];
     const url = await banner.locator('a').first().getAttribute('href');
     console.log(`Current free game: ${chalk.blue(title)} - ${url}`);
     db.data[user][title] ||= { title, time: datetime(), url };
-    if (cfg.dryrun) process.exit(1);
+    if (cfg.dryrun) { console.log('  DRYRUN=1 -> Skip claim!'); process.exit(0); }
     // await page.locator('#giveaway:not(.is-loading)').waitFor(); // otherwise screenshot is sometimes with loading indicator instead of game title; #TODO fix, skipped due to timeout, see #240
     await banner.screenshot({ path: screenshot(`${filenamify(title)}.png`) }); // overwrites every time - only keep first?
 
@@ -123,7 +138,13 @@ try {
       status = 'claimed';
       console.log('  Claimed successfully!');
     } else {
-      const message = JSON.parse(response).message;
+      let message;
+      try {
+        message = JSON.parse(response).message;
+      } catch (_) {
+        console.error('  Unexpected response from GOG claim API:', response);
+        message = response;
+      }
       if (message == 'Already claimed') {
         status = 'existed'; // same status text as for epic-games
         console.log('  Already in library! Nothing to claim.');
@@ -149,6 +170,7 @@ try {
   if (error.message && process.exitCode != 130) notify(`gog failed: ${error.message.split('\n')[0]}`);
 } finally {
   await db.write(); // write out json db
+  writeLastRun('gog');
   if (notify_games.filter(g => g.status != 'existed').length) { // don't notify if all were already claimed
     notify(`gog (${user}):<br>${html_game_list(notify_games)}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fingerprint-injector": "^2.1.66",
         "lowdb": "^7.0.1",
         "otplib": "^12.0.1",
+        "patchright": "^1.59.1",
         "playwright-firefox": "^1.52.0",
         "puppeteer-extra-plugin-stealth": "^2.11.2"
       },
@@ -1386,6 +1387,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2136,6 +2151,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patchright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/patchright/-/patchright-1.59.1.tgz",
+      "integrity": "sha512-nrWFE1/U3qu9ybrgNFJt75iTiszvZ23Dn4S6UDSydbXJtbyBXRVGenHowKq6n7hmArGYPVTfuDqiXVH7avPkiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "patchright-core": "1.59.1"
+      },
+      "bin": {
+        "patchright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/patchright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/patchright-core/-/patchright-core-1.59.1.tgz",
+      "integrity": "sha512-VthHtavFwFgs5VRalZtbacmjw8E7SPXPhGjfOakvjPsrJcIHl/i7K9lgKYpevy4F90+/GQSJiO0Mt58JB4+9HQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "patchright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/path-exists": {
@@ -3786,6 +3831,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4300,6 +4351,20 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "patchright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/patchright/-/patchright-1.59.1.tgz",
+      "integrity": "sha512-nrWFE1/U3qu9ybrgNFJt75iTiszvZ23Dn4S6UDSydbXJtbyBXRVGenHowKq6n7hmArGYPVTfuDqiXVH7avPkiw==",
+      "requires": {
+        "fsevents": "2.3.2",
+        "patchright-core": "1.59.1"
+      }
+    },
+    "patchright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/patchright-core/-/patchright-core-1.59.1.tgz",
+      "integrity": "sha512-VthHtavFwFgs5VRalZtbacmjw8E7SPXPhGjfOakvjPsrJcIHl/i7K9lgKYpevy4F90+/GQSJiO0Mt58JB4+9HQ=="
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fingerprint-injector": "^2.1.66",
     "lowdb": "^7.0.1",
     "otplib": "^12.0.1",
+    "patchright": "^1.59.1",
     "playwright-firefox": "^1.52.0",
     "puppeteer-extra-plugin-stealth": "^2.11.2"
   },

--- a/prime-gaming.js
+++ b/prime-gaming.js
@@ -1,32 +1,51 @@
-import { firefox } from 'playwright-firefox'; // stealth plugin needs no outdated playwright-extra
+import { chromium } from 'patchright'; // patchright patches Chromium to bypass bot detection
 import { authenticator } from 'otplib';
 import chalk from 'chalk';
-import { resolve, jsonDb, datetime, stealth, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT } from './src/util.js';
+import { resolve, jsonDb, datetime, stealth, filenamify, prompt, confirm, notify, html_game_list, handleSIGINT, clearBrowserLock, writeLastRun, generateFingerprint } from './src/util.js';
 import { cfg } from './src/config.js';
 
 const screenshot = (...a) => resolve(cfg.dir.screenshots, 'prime-gaming', ...a);
 
 // const URL_LOGIN = 'https://www.amazon.de/ap/signin'; // wrong. needs some session args to be valid?
-const URL_CLAIM = 'https://gaming.amazon.com/home';
+const BASE_URL = 'https://luna.amazon.com';
+const URL_CLAIM = `${BASE_URL}/claims/home`;
 
 console.log(datetime(), 'started checking prime-gaming');
 
 const db = await jsonDb('prime-gaming.json', {});
 
+clearBrowserLock(cfg.dir.browser);
+
+const fp = generateFingerprint(cfg.width, cfg.height);
+
 // https://playwright.dev/docs/auth#multi-factor-authentication
-const context = await firefox.launchPersistentContext(cfg.dir.browser, {
+const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
   viewport: { width: cfg.width, height: cfg.height },
+  userAgent: fp.fingerprint.navigator.userAgent,
   locale: 'en-US', // ignore OS locale to be sure to have english text for locators
-  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined, // will record a .webm video for each page navigated; without size, video would be scaled down to fit 800x800
-  recordHar: cfg.record ? { path: `data/record/pg-${filenamify(datetime())}.har` } : undefined, // will record a HAR file with network requests and responses; can be imported in Chrome devtools
+  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
+  recordHar: cfg.record ? { path: `data/record/pg-${filenamify(datetime())}.har` } : undefined,
   handleSIGINT: false, // have to handle ourselves and call context.close(), otherwise recordings from above won't be saved
+  args: [
+    '--disable-blink-features=AutomationControlled',
+  ],
 });
 
 handleSIGINT(context);
 
-// TODO test if needed
-await stealth(context);
+// stealth: sets window.chrome, navigator.plugins, etc. + injects consistent fingerprint
+await stealth(context, fp);
+
+// Inject passkey blocker - Amazon shows passkey prompts during login that interrupt automation
+await context.addInitScript(() => {
+  // Reject passkey creation/login prompts silently
+  const reject = () => Promise.reject(new DOMException('Not allowed', 'NotAllowedError'));
+  Object.defineProperty(navigator, 'credentials', {
+    value: { create: reject, get: reject, store: () => Promise.resolve(), preventSilentAccess: () => Promise.resolve() },
+    writable: false,
+  });
+});
 
 if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
 
@@ -59,7 +78,7 @@ try {
       await page.click('input[type="submit"]');
       page.waitForURL('**/ap/signin**').then(async () => { // check for wrong credentials
         const error = await page.locator('.a-alert-content').first().innerText();
-        if (!error.trim.length) return;
+        if (!error.trim().length) return;
         console.error('Login error:', error);
         await notify(`prime-gaming: login: ${error}`);
         await context.close(); // finishes potential recording
@@ -82,7 +101,7 @@ try {
         process.exit(1);
       }
     }
-    await page.waitForURL('https://gaming.amazon.com/home?signedIn=true');
+    await page.waitForURL(`${BASE_URL}/claims/home?signedIn=true`);
     if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
   }
   user = await page.locator('[data-a-target="user-dropdown-first-name-text"]').first().innerText();
@@ -156,7 +175,7 @@ try {
     await card.scrollIntoViewIfNeeded();
     const title = await (await card.$('.item-card-details__body__primary')).innerText();
     const slug = await (await card.$('a')).getAttribute('href');
-    const url = 'https://gaming.amazon.com' + slug.split('?')[0];
+    const url = BASE_URL + slug.split('?')[0];
     console.log('Current free game:', chalk.blue(title));
     if (cfg.pg_timeLeft && await skipBasedOnTime(url)) continue;
     if (cfg.dryrun) continue;
@@ -174,7 +193,7 @@ try {
   for (const card of external) { // need to get data incl. URLs in this loop and then navigate in another, otherwise .all() would update after coming back and .elementHandles() like above would lead to error due to page navigation: elementHandle.$: Protocol error (Page.adoptNode)
     const title = await card.locator('.item-card-details__body__primary').innerText();
     const slug = await card.locator('a:has-text("Claim")').first().getAttribute('href');
-    const url = 'https://gaming.amazon.com' + slug.split('?')[0];
+    const url = BASE_URL + slug.split('?')[0];
     // await (await card.$('text=Claim')).click(); // goes to URL of game, no need to wait
     external_info.push({ title, url });
   }
@@ -375,7 +394,7 @@ try {
     const dlcs = await Promise.all(cards.map(async card => ({
       game: await card.locator('.item-card-details__body p').innerText(),
       title: await card.locator('.item-card-details__body__primary').innerText(),
-      url: 'https://gaming.amazon.com' + await card.locator('a').first().getAttribute('href'),
+      url: BASE_URL + await card.locator('a').first().getAttribute('href'),
     })));
     // console.log(dlcs);
 
@@ -435,6 +454,7 @@ try {
   if (error.message && process.exitCode != 130) notify(`prime-gaming failed: ${error.message.split('\n')[0]}`);
 } finally {
   await db.write(); // write out json db
+  writeLastRun('prime-gaming');
   if (notify_games.length) { // list should only include claimed games
     notify(`prime-gaming (${user}):<br>${html_game_list(notify_games)}`);
   }

--- a/run-scheduled.sh
+++ b/run-scheduled.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Daily scheduler for free-games-claimer.
+# Runs the claim scripts immediately on start, then every day at SCHEDULE_HOUR (default: 7).
+# Set SCHEDULE_HOUR=7 (env) to change the daily run time.
+# Set SCRIPTS env to override which scripts run, e.g. SCRIPTS="node epic-games; node gog"
+
+set -eo pipefail
+
+SCHEDULE_HOUR="${SCHEDULE_HOUR:-7}"
+SCRIPTS="${SCRIPTS:-node epic-games; node prime-gaming; node gog}"
+
+echo "Scheduler started. Will run daily at ${SCHEDULE_HOUR}:00."
+echo "Scripts: ${SCRIPTS}"
+
+while true; do
+  echo ""
+  echo "=== Run started at $(date) ==="
+  eval "$SCRIPTS" || true  # || true so one failure doesn't stop the others
+  # Update healthcheck sentinel
+  mkdir -p /fgc/data 2>/dev/null || true
+  date -Iseconds > /fgc/data/lastrun.json 2>/dev/null || true
+  echo "=== Run finished at $(date) ==="
+
+  # Calculate seconds until next SCHEDULE_HOUR:00
+  now=$(date +%s)
+  next=$(date -d "today ${SCHEDULE_HOUR}:00" +%s 2>/dev/null || date -v "${SCHEDULE_HOUR}H" -v 0M -v 0S +%s)
+  if [ "$next" -le "$now" ]; then
+    next=$(date -d "tomorrow ${SCHEDULE_HOUR}:00" +%s 2>/dev/null || date -v +1d -v "${SCHEDULE_HOUR}H" -v 0M -v 0S +%s)
+  fi
+  sleep_sec=$((next - now))
+  sleep_hr=$(echo "scale=1; $sleep_sec/3600" | bc)
+  echo "Next run in ${sleep_hr}h (at $(date -d "@${next}" 2>/dev/null || date -r "${next}") )"
+  sleep "$sleep_sec"
+done

--- a/src/config.js
+++ b/src/config.js
@@ -15,10 +15,10 @@ export const cfg = {
   get headless() {
     return !this.debug && !this.show;
   },
-  width: Number(process.env.WIDTH) || 1920, // width of the opened browser
-  height: Number(process.env.HEIGHT) || 1080, // height of the opened browser
-  timeout: (Number(process.env.TIMEOUT) || 60) * 1000, // default timeout for playwright is 30s
-  login_timeout: (Number(process.env.LOGIN_TIMEOUT) || 180) * 1000, // higher timeout for login, will wait twice: prompt + wait for manual login
+  width: process.env.WIDTH ? Number(process.env.WIDTH) : 1920, // width of the opened browser
+  height: process.env.HEIGHT ? Number(process.env.HEIGHT) : 1080, // height of the opened browser
+  timeout: ((process.env.TIMEOUT ? Number(process.env.TIMEOUT) : 60)) * 1000, // default timeout for playwright is 30s
+  login_timeout: ((process.env.LOGIN_TIMEOUT ? Number(process.env.LOGIN_TIMEOUT) : 180)) * 1000, // higher timeout for login, will wait twice: prompt + wait for manual login
   novnc_port: process.env.NOVNC_PORT, // running in docker if set
   notify: process.env.NOTIFY, // apprise notification services
   notify_title: process.env.NOTIFY_TITLE, // apprise notification title
@@ -50,4 +50,11 @@ export const cfg = {
   lg_email: process.env.LG_EMAIL || process.env.PG_EMAIL || process.env.EMAIL, // prime-gaming: external: legacy-games: email to use for redeeming
   pg_claimdlc: process.env.PG_CLAIMDLC == '1', // prime-gaming: claim in-game content
   pg_timeLeft: Number(process.env.PG_TIMELEFT), // prime-gaming: check time left to claim and skip game if there are more than PG_TIMELEFT days left to claim it
+  // auth steam
+  steam_username: process.env.STEAM_USERNAME,
+  steam_password: process.env.STEAM_PASSWORD,
+  steam_otpkey: process.env.STEAM_OTPKEY, // Steam Guard app OTP key (base32)
+  // notifications: Telegram (alternative/addition to apprise)
+  tg_token: process.env.TG_TOKEN,       // Telegram bot token (from @BotFather)
+  tg_chat_id: process.env.TG_CHAT_ID,   // Telegram chat/channel ID
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,69 @@
 // https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+const _require = createRequire(import.meta.url);
+const { FingerprintGenerator } = _require('fingerprint-generator');
+const { FingerprintInjector } = _require('fingerprint-injector');
+const _fingerprintGenerator = new FingerprintGenerator({ browsers: [{ name: 'chrome', minVersion: 130 }], devices: ['desktop'], operatingSystems: ['windows'] });
+const _fingerprintInjector = new FingerprintInjector();
+
+// Load a persistent fingerprint from disk, generating it once on first run.
+// A real user always appears as the same "computer" - same canvas hash, WebGL renderer, fonts, etc.
+// Regenerating every run is more suspicious than a stable identity.
+// Delete data/fingerprint.json to force a new fingerprint (e.g. after changing WIDTH/HEIGHT).
+export const generateFingerprint = (width = 1920, height = 1080) => {
+  const fpFile = dataDir('fingerprint.json');
+  if (existsSync(fpFile)) {
+    try {
+      return JSON.parse(_require('node:fs').readFileSync(fpFile, 'utf8'));
+    } catch (_) { /* corrupted file - regenerate */ }
+  }
+  let fp;
+  try {
+    fp = _fingerprintGenerator.getFingerprint({ screen: { minWidth: width, maxWidth: width, minHeight: height, maxHeight: height } });
+  } catch (_) {
+    fp = _fingerprintGenerator.getFingerprint();
+  }
+  try {
+    writeFileSync(fpFile, JSON.stringify(fp, null, 2));
+    console.log('Generated new browser fingerprint, saved to', fpFile);
+  } catch (_) { /* non-critical */ }
+  return fp;
+};
 // not the same since these will give the absolute paths for this file instead of for the file using them
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 // explicit object instead of Object.fromEntries since the built-in type would loose the keys, better type: https://dev.to/svehla/typescript-object-fromentries-389c
 export const dataDir = s => path.resolve(__dirname, '..', 'data', s);
+
+// Remove stale browser profile lock left behind by a crashed/killed previous run.
+// Firefox uses parent.lock, Chromium/patchright uses SingletonLock.
+// On Windows the file is held open by the process, so if removal fails the profile is still in use.
+export const clearBrowserLock = (dir) => {
+  for (const lockName of ['parent.lock', 'SingletonLock', 'SingletonCookie', 'SingletonSocket']) {
+    const lockFile = path.join(dir, lockName);
+    if (existsSync(lockFile)) {
+      try {
+        unlinkSync(lockFile);
+        console.log('Removed stale browser lock file:', lockFile);
+      } catch (_) {
+        console.error(`Browser profile is already in use: ${lockFile}`);
+        console.error('Close other browser instances sharing this profile, or set a different BROWSER_DIR.');
+        process.exit(1);
+      }
+    }
+  }
+};
+
+// Write a lastrun timestamp so Docker HEALTHCHECK can verify the scheduler is alive.
+export const writeLastRun = (script) => {
+  try {
+    const p = dataDir('lastrun.json');
+    writeFileSync(p, JSON.stringify({ script, time: new Date().toISOString() }));
+  } catch (_) { /* non-critical */ }
+};
 
 // modified path.resolve to return null if first argument is '0', used to disable screenshots
 export const resolve = (...a) => a.length && a[0] == '0' ? null : path.resolve(...a);
@@ -22,41 +80,33 @@ export const datetime = (d = new Date()) => datetimeUTC(new Date(d.getTime() - d
 export const filenamify = s => s.replaceAll(':', '.').replace(/[^a-z0-9 _\-.]/gi, '_'); // alternative: https://www.npmjs.com/package/filenamify - On Unix-like systems, / is reserved. On Windows, <>:"/\|?* along with trailing periods are reserved.
 
 export const handleSIGINT = (context = null) => process.on('SIGINT', async () => { // e.g. when killed by Ctrl-C
-  console.error('\nInterrupted by SIGINT. Exit!'); // Exception shows where the script was:\n'); // killed before catch in docker...
+  console.error('\nInterrupted by SIGINT. Exit!');
   process.exitCode = 130; // 128+SIGINT to indicate to parent that process was killed
   if (context) await context.close(); // in order to save recordings also on SIGINT, we need to disable Playwright's handleSIGINT and close the context ourselves
 });
 
-export const launchChromium = async options => {
-  const { chromium } = await import('playwright-chromium'); // stealth plugin needs no outdated playwright-extra
-
-  // https://www.nopecha.com extension source from https://github.com/NopeCHA/NopeCHA/releases/tag/0.1.16
-  // const ext = path.resolve('nopecha'); // used in Chromium, currently not needed in Firefox
-
-  const context = chromium.launchPersistentContext(cfg.dir.browser, {
-    // chrome will not work in linux arm64, only chromium
-    // channel: 'chrome', // https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
-    args: [ // https://peter.sh/experiments/chromium-command-line-switches
-      // don't want to see bubble 'Restore pages? Chrome didn't shut down correctly.'
-      // '--restore-last-session', // does not apply for crash/killed
-      '--hide-crash-restore-bubble',
-      // `--disable-extensions-except=${ext}`,
-      // `--load-extension=${ext}`,
-    ],
-    // ignoreDefaultArgs: ['--enable-automation'], // remove default arg that shows the info bar with 'Chrome is being controlled by automated test software.'. Since Chromeium 106 this leads to show another info bar with 'You are using an unsupported command-line flag: --no-sandbox. Stability and security will suffer.'.
-    ...options,
-  });
-  return context;
+// Retry wrapper - retries an async function on failure with delay between attempts.
+export const withRetry = async (label, fn, { retries = 3, delayMs = 30000 } = {}) => {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i >= retries - 1) throw e;
+      console.error(`${label}: attempt ${i + 1}/${retries} failed: ${e.message?.split('\n')[0]}`);
+      console.log(`Retrying in ${delayMs / 1000}s...`);
+      await delay(delayMs);
+    }
+  }
 };
 
-export const stealth = async context => {
+export const stealth = async (context, fingerprint = null) => {
   // stealth with playwright: https://github.com/berstend/puppeteer-extra/issues/454#issuecomment-917437212
   // https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth/evasions
   const enabledEvasions = [
     'chrome.app',
     'chrome.csi',
     'chrome.loadTimes',
-    'chrome.runtime',
+    'chrome.runtime', // partially broken in Chrome 100+, patched below
     // 'defaultArgs',
     'iframe.contentWindow',
     'media.codecs',
@@ -84,6 +134,39 @@ export const stealth = async context => {
   for (const evasion of stealth.callbacks) {
     await context.addInitScript(evasion.cb, evasion.a);
   }
+
+  // fingerprint-injector: injects canvas fingerprint, WebGL renderer/vendor, font metrics,
+  // navigator properties (hardwareConcurrency, deviceMemory, languages, plugins, etc.)
+  // and sets matching sec-ch-ua / user-agent HTTP headers.
+  // Must run BEFORE the chrome.runtime patch so the patch isn't overwritten.
+  if (fingerprint) {
+    await _fingerprintInjector.attachFingerprintToPlaywright(context, fingerprint);
+  }
+
+  // chrome.runtime patch: puppeteer-extra-plugin-stealth's version is broken in Chrome 100+
+  // because the real runtime object structure changed. We patch it manually.
+  // Without this, bot detectors see window.chrome.runtime === undefined which is detectable.
+  await context.addInitScript(() => {
+    if (!window.chrome) return;
+    if (window.chrome.runtime && window.chrome.runtime.PlatformOs) return; // already set correctly (non-headless real Chrome)
+    try {
+      Object.defineProperty(window.chrome, 'runtime', {
+        value: {
+          PlatformOs: { MAC: 'mac', WIN: 'win', ANDROID: 'android', CROS: 'cros', LINUX: 'linux', OPENBSD: 'openbsd' },
+          PlatformArch: { ARM: 'arm', ARM64: 'arm64', X86_32: 'x86-32', X86_64: 'x86-64', MIPS: 'mips', MIPS64: 'mips64' },
+          RequestUpdateCheckStatus: { THROTTLED: 'throttled', NO_UPDATE: 'no_update', UPDATE_AVAILABLE: 'update_available' },
+          OnInstalledReason: { INSTALL: 'install', UPDATE: 'update', CHROME_UPDATE: 'chrome_update', SHARED_MODULE_UPDATE: 'shared_module_update' },
+          OnRestartRequiredReason: { APP_UPDATE: 'app_update', OS_UPDATE: 'os_update', PERIODIC: 'periodic' },
+          connect: () => { throw new Error('Extension context invalidated.'); },
+          sendMessage: () => { throw new Error('Extension context invalidated.'); },
+          id: undefined,
+        },
+        writable: false,
+        enumerable: false,
+        configurable: false,
+      });
+    } catch (_) { /* already defined by real Chrome runtime - that's fine */ }
+  });
 };
 
 // used prompts before, but couldn't cancel prompt
@@ -106,33 +189,56 @@ enquirer.use(timeoutPlugin(cfg.login_timeout)); // TODO may not want to have thi
 export const prompt = o => enquirer.prompt({ name: 'name', type: 'input', message: 'Enter value', ...o }).then(r => r.name).catch(_ => {});
 export const confirm = o => prompt({ type: 'confirm', message: 'Continue?', ...o });
 
-// notifications via apprise CLI
+// notifications via apprise CLI (set NOTIFY env var)
 import { execFile } from 'child_process';
 import { cfg } from './config.js';
 
-export const notify = html => new Promise((resolve, reject) => {
+export const notify = html => {
+  notifyTelegram(html).catch(_ => {}); // fire-and-forget Telegram in parallel
   if (!cfg.notify) {
     if (cfg.debug) console.debug('notify: NOTIFY is not set!');
-    return resolve();
+    return Promise.resolve();
   }
-  // const cmd = `apprise '${cfg.notify}' ${title} -i html -b '${html}'`; // this had problems if e.g. ' was used in arg; could have `npm i shell-escape`, but instead using safer execFile which takes args as array instead of exec which spawned a shell to execute the command
-  const args = [cfg.notify, '-i', 'html', '-b', `'${html}'`];
-  if (cfg.notify_title) args.push(...['-t', cfg.notify_title]);
-  if (cfg.debug) console.debug(`apprise ${args.map(a => `'${a}'`).join(' ')}`); // this also doesn't escape, but it's just for info
-  execFile('apprise', args, (error, stdout, stderr) => {
-    if (error) {
-      console.log(`error: ${error.message}`);
-      if (error.message.includes('command not found')) {
-        console.info('Run `pip install apprise`. See https://github.com/vogler/free-games-claimer#notifications');
+  return new Promise((resolve, reject) => {
+    const args = [cfg.notify, '-i', 'html', '-b', `'${html}'`];
+    if (cfg.notify_title) args.push(...['-t', cfg.notify_title]);
+    if (cfg.debug) console.debug(`apprise ${args.map(a => `'${a}'`).join(' ')}`);
+    execFile('apprise', args, (error, stdout, stderr) => {
+      if (error) {
+        console.log(`error: ${error.message}`);
+        if (error.message.includes('command not found')) {
+          console.info('Run `pip install apprise` or set TG_TOKEN+TG_CHAT_ID for Telegram. See README.');
+        }
+        return reject(error);
       }
-      return reject(error);
-    }
-    if (stderr) console.error(`stderr: ${stderr}`);
-    if (stdout) console.log(`stdout: ${stdout}`);
-    resolve();
+      if (stderr) console.error(`stderr: ${stderr}`);
+      if (stdout) console.log(`stdout: ${stdout}`);
+      resolve();
+    });
   });
-});
+};
+
+// Direct Telegram notification without Apprise (set TG_TOKEN and TG_CHAT_ID env vars).
+// Works independently of NOTIFY/apprise - can be used alongside or as replacement.
+export const notifyTelegram = async (html) => {
+  if (!cfg.tg_token || !cfg.tg_chat_id) return;
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${cfg.tg_token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: cfg.tg_chat_id,
+        text: html,
+        parse_mode: 'HTML',
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!res.ok) console.error('Telegram notification error:', await res.text());
+  } catch (e) {
+    console.error('Telegram notification failed:', e.message);
+  }
+};
 
 export const escapeHtml = unsafe => unsafe.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll('\'', '&#039;');
 
-export const html_game_list = games => games.map(g => `- <a href="${g.url}">${escapeHtml(g.title)}</a> (${g.status})`).join('<br>');
+export const html_game_list = games => games.map(g => `- <a href="${escapeHtml(g.url)}">${escapeHtml(g.title)}</a> (${g.status})`).join('<br>'); // status may intentionally contain HTML (e.g. redeem links from prime-gaming)

--- a/steam-games.js
+++ b/steam-games.js
@@ -1,73 +1,218 @@
-import { firefox } from 'playwright-firefox'; // stealth plugin needs no outdated playwright-extra
-import { jsonDb, prompt } from './src/util.js';
+import { chromium } from 'patchright';
+import { authenticator } from 'otplib';
+import chalk from 'chalk';
+import { jsonDb, datetime, stealth, prompt, notify, html_game_list, handleSIGINT, clearBrowserLock, writeLastRun, withRetry, generateFingerprint } from './src/util.js';
 import { cfg } from './src/config.js';
+
+const URL_STORE = 'https://store.steampowered.com';
+const URL_LOGIN = `${URL_STORE}/login/`;
+const GAMERPOWER_API = 'https://www.gamerpower.com/api/giveaways?platform=steam&type=game&status=active';
+
+console.log(datetime(), 'started checking steam-games');
 
 const db = await jsonDb('steam-games.json', {});
 
-const user = cfg.steam_id || await prompt({ message: 'Enter Steam community id ("View my profile", then copy from URL)' });
+// Fetch active Steam giveaways from GamerPower API
+const fetchGiveaways = async () => {
+  try {
+    const res = await fetch(GAMERPOWER_API, {
+      headers: { 'User-Agent': 'free-games-claimer/1.0' },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch (e) {
+    console.error('GamerPower API error:', e.message);
+    return [];
+  }
+};
 
-// using https://github.com/apify/fingerprint-suite worked, but has no launchPersistentContext...
-// from https://github.com/apify/fingerprint-suite/issues/162
-import { FingerprintInjector } from 'fingerprint-injector';
-import { FingerprintGenerator } from 'fingerprint-generator';
+clearBrowserLock(cfg.dir.browser);
 
-const { fingerprint, headers } = new FingerprintGenerator().getFingerprint({
-    devices: ["desktop"],
-    operatingSystems: ["windows"],
-});
+const fp = generateFingerprint(cfg.width, cfg.height);
 
-const context = await firefox.launchPersistentContext(cfg.dir.browser, {
+const context = await chromium.launchPersistentContext(cfg.dir.browser, {
   headless: cfg.headless,
-  // viewport: { width: cfg.width, height: cfg.height },
-  locale: 'en-US', // ignore OS locale to be sure to have english text for locators -> done via /en in URL
-  userAgent: fingerprint.navigator.userAgent,
-  viewport: {
-      width: fingerprint.screen.width,
-      height: fingerprint.screen.height,
-  },
-  extraHTTPHeaders: {
-      'accept-language': headers['accept-language'],
-  },
+  viewport: { width: cfg.width, height: cfg.height },
+  userAgent: fp.fingerprint.navigator.userAgent,
+  locale: 'en-US',
+  recordVideo: cfg.record ? { dir: 'data/record/', size: { width: cfg.width, height: cfg.height } } : undefined,
+  handleSIGINT: false,
+  args: ['--disable-blink-features=AutomationControlled'],
 });
-// await stealth(context);
-await new FingerprintInjector().attachFingerprintToPlaywright(context, { fingerprint, headers });
 
-context.setDefaultTimeout(cfg.debug ? 0 : cfg.timeout);
+handleSIGINT(context);
+await stealth(context, fp);
 
-const page = context.pages().length ? context.pages()[0] : await context.newPage(); // should always exist
+if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
+
+const page = context.pages().length ? context.pages()[0] : await context.newPage();
+await page.setViewportSize({ width: cfg.width, height: cfg.height });
+
+const notify_games = [];
+let user = 'unknown';
 
 try {
-  await page.goto(`https://steamcommunity.com/id/${user}/games?tab=all`);
-  const games = page.locator('div[data-featuretarget="gameslist-root"] > div.Panel > div.Panel > div');
-  await games.last().waitFor();
-  await page.keyboard.press('End');
-  await page.waitForLoadState('networkidle');
-  console.log('All Games:', await games.count());
-  for (const game of await games.all()) {
-    const title = await game.locator('span a').innerText();
-    let time, last, achievements, size;
-    const ltime = game.locator('span:has-text("total played")');
-    if (await ltime.count()) time = (await ltime.first().innerText()).split('\n')[1];
-    const llast = game.locator('span:has-text("last played")');
-    if (await llast.count()) last = (await llast.first().innerText()).split('\n')[1];
-    const lachievements = game.locator('a:has-text("achievements") + span');
-    if (await lachievements.count()) achievements = (await lachievements.first().innerText()).split('\n');
-    const lsize = game.locator('span:has(+ button)');
-    if (await lsize.count()) size = await lsize.first().innerText();
-    const url = await game.locator('a').first().getAttribute('href');
-    const img = await game.locator('img').first().getAttribute('src');
-    const stat = { title, time, last, achievements, size, url, img };
-    console.log(stat);
-    db.data[title] = stat;
+  await page.goto(URL_STORE, { waitUntil: 'domcontentloaded' });
+
+  const isLoggedIn = async () => (await page.locator('#account_pulldown, a.username, .persona_name_text_content').count()) > 0;
+
+  if (!await isLoggedIn()) {
+    console.error('Not signed in to Steam. Please login.');
+    if (cfg.novnc_port) console.info(`Open http://localhost:${cfg.novnc_port} to login inside Docker.`);
+    if (!cfg.debug) context.setDefaultTimeout(cfg.login_timeout);
+    console.info(`Login timeout is ${cfg.login_timeout / 1000} seconds!`);
+
+    await page.goto(URL_LOGIN, { waitUntil: 'domcontentloaded' });
+
+    if (cfg.steam_username && cfg.steam_password) {
+      console.info('Using credentials from environment.');
+      await page.locator('input[type="text"][autocomplete="username"]').fill(cfg.steam_username);
+      await page.locator('input[type="password"]').fill(cfg.steam_password);
+      await page.locator('button[type="submit"]').click();
+
+      // Steam Guard — email or app code
+      const guardInput = page.locator('input[maxlength="5"], input[maxlength="6"], input[data-input-type="password"]').first();
+      await guardInput.waitFor({ timeout: 15000 }).then(async () => {
+        console.log('Steam Guard required.');
+        const otp = cfg.steam_otpkey && authenticator.generate(cfg.steam_otpkey)
+          || await prompt({ type: 'text', message: 'Enter Steam Guard code (email or app)', validate: n => n.toString().length >= 5 || 'Must be 5-6 digits' });
+        if (otp) {
+          await guardInput.fill(otp.toString());
+          await page.locator('button[type="submit"]').click();
+        }
+      }).catch(_ => { }); // no guard needed
+    } else {
+      console.info('Press ESC to skip prompts and login manually in the browser.');
+      const username = await prompt({ message: 'Steam username' });
+      const password = username && await prompt({ type: 'password', message: 'Steam password' });
+      if (username && password) {
+        await page.locator('input[type="text"]').fill(username);
+        await page.locator('input[type="password"]').fill(password);
+        await page.locator('button[type="submit"]').click();
+      }
+    }
+
+    await page.waitForURL(`${URL_STORE}/**`, { timeout: cfg.login_timeout });
+    if (!cfg.debug) context.setDefaultTimeout(cfg.timeout);
   }
 
-  // await page.pause();
+  user = await page.locator('#account_pulldown').first().innerText().catch(
+    () => page.locator('.persona_name_text_content').first().innerText().catch(() => 'unknown')
+  );
+  console.log(`Signed in as ${user}`);
+  db.data[user] ||= {};
+
+  // Fetch giveaways from GamerPower API
+  console.log('\nFetching active Steam giveaways from GamerPower...');
+  const giveaways = await fetchGiveaways();
+  if (!giveaways.length) {
+    console.log('No active Steam giveaways found.');
+  } else {
+    console.log(`Found ${giveaways.length} active giveaway(s).`);
+  }
+
+  for (const giveaway of giveaways) {
+    const title = giveaway.title;
+    const store_url = giveaway.store_url || '';
+    const game_id = store_url.match(/\/app\/(\d+)/)?.[1] || giveaway.id?.toString();
+
+    if (!store_url.includes('store.steampowered.com')) {
+      console.log(`Skipping non-Steam URL: ${store_url}`);
+      continue;
+    }
+
+    if (db.data[user][game_id]?.status === 'claimed') {
+      console.log(`Already claimed: ${chalk.blue(title)}`);
+      continue;
+    }
+
+    db.data[user][game_id] ||= { title, time: datetime(), url: store_url };
+    console.log(`\nGiveaway: ${chalk.blue(title)}`);
+    console.log(`  URL: ${store_url}`);
+    console.log(`  Ends: ${giveaway.end_date || 'unknown'}`);
+
+    const notify_game = { title, url: store_url, status: 'failed' };
+    notify_games.push(notify_game);
+
+    if (cfg.dryrun) {
+      console.log('  DRYRUN=1 -> Skip!');
+      notify_game.status = 'skipped';
+      continue;
+    }
+
+    try {
+      await withRetry(`steam claim ${title}`, async () => {
+        await page.goto(store_url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+        // Handle age gate
+        if (await page.locator('#app_agegate, #agecheck_form, .agegate_birthday_selector').count()) {
+          console.log('  Handling age gate...');
+          await page.selectOption('#ageYear', '1990').catch(() => {});
+          await page.locator('#age_gate_btn_continue, a[href*="agecheck"]').click().catch(() => {});
+          await page.waitForTimeout(1500);
+        }
+
+        // Check if already owned
+        if (await page.locator('.game_area_already_owned, :has-text("already in your Steam library")').count()) {
+          console.log('  Already in library!');
+          db.data[user][game_id].status = notify_game.status = 'existed';
+          return;
+        }
+
+        // Find claim button (various types of free games on Steam)
+        const claimSelectors = [
+          'a.btn_green_steamui:has-text("Add to Account")',
+          'a.btn_green_steamui:has-text("Play Game, Free")',
+          'a.btn_green_steamui:has-text("Free to Play")',
+          'a[href*="checkout/addfreelicense"]:visible',
+          '.game_area_purchase_game a.btn_green_steamui:visible',
+        ];
+        const claimBtn = page.locator(claimSelectors.join(', ')).first();
+
+        if (!await claimBtn.count()) {
+          console.log('  No claim button found — may require account linking or be unavailable.');
+          db.data[user][game_id].status = notify_game.status = 'not-available';
+          return;
+        }
+
+        await claimBtn.click();
+
+        // Confirm dialog ("Add to my account" button in modal)
+        const confirmBtn = page.locator('a.btn_green_steamui:has-text("Add to my account"), .newmodal_buttons a:has-text("OK")').first();
+        await confirmBtn.waitFor({ timeout: 5000 }).then(() => confirmBtn.click()).catch(() => {});
+        await page.waitForTimeout(2000);
+
+        // Verify success
+        const success = await page.locator('.game_area_already_owned, :has-text("is now in your library"), :has-text("already in your Steam")').count();
+        if (success) {
+          db.data[user][game_id].status = notify_game.status = 'claimed';
+          db.data[user][game_id].time = datetime();
+          console.log('  Claimed successfully!');
+        } else {
+          console.log('  Result unclear — check manually.');
+          db.data[user][game_id].status = notify_game.status = 'claimed?';
+        }
+      }, { retries: 2, delayMs: 10000 });
+    } catch (e) {
+      console.error(`  Failed: ${e.message?.split('\n')[0]}`);
+      db.data[user][game_id].status = notify_game.status = 'failed';
+    }
+  }
+
 } catch (error) {
   process.exitCode ||= 1;
   console.error('--- Exception:');
-  console.error(error); // .toString()?
+  console.error(error);
+  if (error.message && process.exitCode != 130) notify(`steam-games failed: ${error.message.split('\n')[0]}`);
 } finally {
-  await db.write(); // write out json db
+  await db.write();
+  writeLastRun('steam-games');
+  const toNotify = notify_games.filter(g => g.status === 'claimed' || g.status === 'claimed?' || g.status === 'failed');
+  if (toNotify.length) {
+    notify(`steam-games (${user}):<br>${html_game_list(toNotify)}`);
+  }
 }
 if (page.video()) console.log('Recorded video:', await page.video().path());
 await context.close();


### PR DESCRIPTION
## Summary

- **Firefox → patchright (Chromium)**: all store scripts now use `patchright` — a patched Chromium fork that bypasses bot-detection at the binary level, combined with `fingerprint-injector` for a persistent, realistic browser fingerprint cached to disk
- **Steam claimer rewrite**: discovers free games via GamerPower API, handles full login flow with Steam Guard TOTP, age gates, and already-owned detection
- **Daily scheduler** (`run-scheduled.sh`): runs scripts immediately on start, then waits until `SCHEDULE_HOUR:00` (default `07:00`) each day — designed for Portainer/Docker Compose with `restart: unless-stopped`
- **Docker HEALTHCHECK**: fails if `lastrun.json` wasn't updated in the last 25 hours — Portainer marks the container unhealthy if the scheduler is stuck
- **Native Telegram notifications** (`TG_TOKEN` + `TG_CHAT_ID`): no Apprise/pip dependency required; runs in parallel with Apprise if both are set
- **Bug fixes**: `.X1-lock` typo in entrypoint, `error.trim.length` in prime-gaming, `Number(env)||default` (breaks for 0), GOG dryrun exit code, deprecated `>>` selector in epic-games

## Changes by file

| File | Change |
|------|--------|
| `epic-games.js` | firefox→patchright, withRetry for goto, fix deprecated `>>` selector, fix `page.innerHTML`, add writeLastRun |
| `prime-gaming.js` | firefox→patchright, `gaming.amazon.com`→`luna.amazon.com`, fix `trim()` bug, block passkey prompts, add writeLastRun |
| `gog.js` | firefox→patchright, add stealth+fingerprint (was missing), fix dryrun exit code 0, safer API response parsing, add writeLastRun |
| `steam-games.js` | complete rewrite: GamerPower API discovery, full login + Steam Guard TOTP, age gate, already-owned detection |
| `src/util.js` | add `clearBrowserLock`, `writeLastRun`, `withRetry`, `generateFingerprint` (persistent), `notifyTelegram`; `stealth()` accepts fingerprint param |
| `src/config.js` | add `steam_username/password/otpkey`, `tg_token/tg_chat_id`; fix `Number(env)\|\|default` → `env?Number(env):default` |
| `Dockerfile` | add Chromium system deps, replace firefox install with `patchright install chromium`, add HEALTHCHECK, add `steam-games` to CMD |
| `docker-compose.yml` | `restart: unless-stopped`, default CMD → `run-scheduled.sh`, full env var comments for all stores |
| `docker-entrypoint.sh` | fix typo: `.X1-lock` → `.X11-lock` |
| `run-scheduled.sh` | new: bash daily scheduler |

## Test plan

- [ ] `SHOW=1 DRYRUN=1 node epic-games` — browser opens, games listed, no claim made
- [ ] `SHOW=1 DRYRUN=1 node prime-gaming` — navigates to `luna.amazon.com`, lists games
- [ ] `SHOW=1 DRYRUN=1 node gog` — lists current GOG giveaway
- [ ] `SHOW=1 DRYRUN=1 node steam-games` — fetches GamerPower API, lists active giveaways
- [ ] `docker compose up -d` — container starts, runs scripts, restarts daily at 07:00, HEALTHCHECK passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)